### PR TITLE
Update runtime, fix gsound build system

### DIFF
--- a/org.gnome.BreakTimer.json
+++ b/org.gnome.BreakTimer.json
@@ -1,7 +1,7 @@
 {
     "id" : "org.gnome.BreakTimer",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.38",
+    "runtime-version" : "40",
     "sdk" : "org.gnome.Sdk",
     "command" : "gnome-break-timer-settings",
     "finish-args" : [
@@ -33,6 +33,7 @@
         },
         {
             "name" : "gsound",
+            "buildsystem" : "meson",
             "sources" : [
                 {
                     "type" : "git",

--- a/org.gnome.BreakTimer.json
+++ b/org.gnome.BreakTimer.json
@@ -38,7 +38,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/gsound.git",
-                    "branch" : "master"
+                    "tag" : "1.0.3"
                 }
             ]
         },


### PR DESCRIPTION
`org.gnome.Platform//3.38` is end of life, so I updated that.
Also, the build failed due to gsound switching from autotools to meson, so I fixed that.

(fixes #2)