### PR TITLE
chore(update): org.gnome.Platform 41 and more

### DIFF
--- a/org.gnome.BreakTimer.json
+++ b/org.gnome.BreakTimer.json
@@ -1,7 +1,7 @@
 {
     "id" : "org.gnome.BreakTimer",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "40",
+    "runtime-version" : "41",
     "sdk" : "org.gnome.Sdk",
     "command" : "gnome-break-timer-settings",
     "finish-args" : [

--- a/org.gnome.BreakTimer.json
+++ b/org.gnome.BreakTimer.json
@@ -13,7 +13,8 @@
         "--talk-name=org.gnome.Shell",
         "--talk-name=org.gnome.Mutter.IdleMonitor",
         "--talk-name=org.gnome.ScreenSaver",
-        "--talk-name=org.freedesktop.Notifications"
+        "--talk-name=org.freedesktop.Notifications",
+        "--device=dri"
     ],
     "modules" : [
         {


### PR DESCRIPTION
Update to new GNOME runtime and add `device=dri` for hardware accelerated rendering. Testing this build now and LGTM.