### PR TITLE
chore(update): org.gnome.Platform 43

### DIFF
--- a/org.gnome.BreakTimer.json
+++ b/org.gnome.BreakTimer.json
@@ -1,7 +1,7 @@
 {
     "id" : "org.gnome.BreakTimer",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "41",
+    "runtime-version" : "43",
     "sdk" : "org.gnome.Sdk",
     "command" : "gnome-break-timer-settings",
     "finish-args" : [


### PR DESCRIPTION
Tested and LGTM so far.

`org.gnome.Platform 41` EOL soon so we must to update supported version. Thanks!